### PR TITLE
Improve filter output message organization

### DIFF
--- a/lib/fluent/plugin/filter_process_snmptrap.rb
+++ b/lib/fluent/plugin/filter_process_snmptrap.rb
@@ -53,7 +53,7 @@ module Fluent
       record["sensorValue"] = ""
       record["error"] = ""
       record["message"] = ""
-      record["timestamp"] = ""
+      record["time"] = ""
 
       determineMachineId(record)
       getrmcHost(record)
@@ -61,7 +61,7 @@ module Fluent
       determineSensorValue(record)
       determineStatus(record)
       makeMessage(record)
-      record["timestamp"] = time
+      record["time"] = time
       record.delete_if { |key, value| key.to_s.match(/(?:SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}|(host))/)}
       return record
     end
@@ -69,7 +69,6 @@ module Fluent
     def makeMessage(record)
       message = 
       {
-        :timestamp => @time,
         :source => "snmp",
         :host => record[@@host],
         :device => record[@@device],

--- a/lib/fluent/plugin/filter_process_snmptrap.rb
+++ b/lib/fluent/plugin/filter_process_snmptrap.rb
@@ -1,4 +1,5 @@
 require 'fluent/plugin/filter'
+require 'json'
 
 module Fluent
   class ProcessSnmptrap < Filter
@@ -11,7 +12,7 @@ module Fluent
     @@snmptrapOid = "SNMPv2-MIB::snmpTrapOID.0"
     @@rmcSerialNum = "SNMPv2-SMI::enterprises.59.3.800.10.10.1.1"
     @@chassisBMCId = "SNMPv2-SMI::enterprises.59.3.800.10.30.1.1"
-    @@sensor = "SNMPv2-SMI::enterprises.59.3.800.30.10.1.1"
+    @@device = "SNMPv2-SMI::enterprises.59.3.800.30.10.1.1"
     @@status = "SNMPv2-SMI::enterprises.59.3.800.30.10.1.4"
     @@sensorValue = "SNMPv2-SMI::enterprises.59.3.800.30.10.1.2"
     @@host = "host"
@@ -38,14 +39,16 @@ module Fluent
     end
 
     def filter(tag, time, record)
+      @time = time
+      @tag = tag
       message = record.to_s
       message = message.delete('\\"')
       snmp_msg = message.gsub(/(?:(SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}(=>))|(host=>))/, "")
       record["machineId"] = ""
-      record["rmc_host"] = ""
+      record["rmcHostIP"] = ""
       record["event"] = ""
       record["status"] = ""
-      record["sensor"] = ""
+      record["device"] = ""
       record["severity"] = ""
       record["sensorValue"] = ""
       record["error"] = ""
@@ -53,14 +56,26 @@ module Fluent
       record["timestamp"] = ""
 
       determineMachineId(record)
-      getrmchost(record)
+      getrmcHost(record)
       processEvent(record)
       determineSensorValue(record)
       determineStatus(record)
-      record["message"] = snmp_msg
+      makeMessage(record)
       record["timestamp"] = time
       record.delete_if { |key, value| key.to_s.match(/(?:SNMPv2-(\w+)(::)(\w+)((\.)(\d+)){1,13}|(host))/)}
       return record
+    end
+
+    def makeMessage(record)
+      message = 
+      {
+        :timestamp => @time,
+        :source => "snmp",
+        :host => record[@@host],
+        :device => record[@@device],
+        :status => record[@@status],
+      }
+      record["message"] = message.to_json
     end
 
     def determineMachineId(record)
@@ -80,12 +95,12 @@ module Fluent
       end
     end
 
-    def getrmchost(record)
-      rmc_host = record[@@host]
-      if rmc_host.nil?
+    def getrmcHost(record)
+      host = record[@@host]
+      if host.nil?
         record["error"] << " : Can not Determine the host IP"
       end
-      record["rmc_host"] = rmc_host
+      record["rmcHostIP"] = host
     end
 
     def determineSensorValue(record)
@@ -99,9 +114,9 @@ module Fluent
     end
 
     def determineEvent(record)
-      sensor = record[@@sensor]
-      record["sensor"] = sensor
-      if sensor == "SYSPOWERSTATE"
+      device = record[@@device]
+      record["device"] = device
+      if device == "SYSPOWERSTATE"
         if record[@@status].to_s == ServerPowerUp
           event = @@serverPowerUp
         elsif record[@@status].to_s == ServerPowerDown

--- a/test/plugin/test_filter_process_snmptrap.rb
+++ b/test/plugin/test_filter_process_snmptrap.rb
@@ -1,7 +1,7 @@
 require "fluent/test"
 require "fluent/test/driver/filter"
 require "fluent/test/helpers"
-require "/etc/fluent/plugin/filter_process_snmptrap.rb"
+require "fluent/plugin/filter_process_snmptrap.rb"
 
 class ProcessSnmptrapFilterTest < Test::Unit::TestCase
   include Fluent::Test::Helpers
@@ -12,9 +12,7 @@ class ProcessSnmptrapFilterTest < Test::Unit::TestCase
 
   CONFIG = %[
     @type process_snmptrap
-    HPEHostName HPETesthost
     coloregion testcolo
-    domain hpetestdomain
   ]
 
 
@@ -25,14 +23,13 @@ class ProcessSnmptrapFilterTest < Test::Unit::TestCase
   def test_configure
       d = create_driver(CONFIG)
       assert_equal 'testcolo', d.instance.coloregion
-      assert_equal 'hpetestdomain', d.instance.domain
   end
 
   def filter(records, conf = CONFIG)
       d = create_driver(conf)
       d.run(default_tag: "TestTrap") do
          records.each do |record|
-            d.feed(record)
+             d.feed(record)
          end
       end
       d.filtered_records
@@ -42,17 +39,16 @@ class ProcessSnmptrapFilterTest < Test::Unit::TestCase
   def test_snmptrap_filter
     records = [
         {
-                "SNMPv2-MIB::sysUpTime.0":"43 days, 21:28:56.10","SNMPv2-MIB::snmpTrapOID.0":"SNMPv2-SMI::enterprises.59.3.800.100.20.3","SNMPv2-SMI::enterprises.59.3.800.10.10.1.1":"UV300-00000550","SNMPv2-SMI::enterprises.59.3.800.10.30.1.1":"r001i01b","SNMPv2-SMI::enterprises.59.3.800.30.10.1.1":"SYSPOWERSTATE","SNMPv2-SMI::enterprises.59.3.800.30.10.1.2":"0x0","SNMPv2-SMI::enterprises.59.3.800.30.10.1.4":"18","host":"192.168.254.61"
+                "SNMPv2-MIB::sysUpTime.0"=>"43 days, 21:28:56.10","SNMPv2-MIB::snmpTrapOID.0"=>"SNMPv2-SMI::enterprises.59.3.800.100.20.3","SNMPv2-SMI::enterprises.59.3.800.10.10.1.1"=>"UV300-00000550","SNMPv2-SMI::enterprises.59.3.800.10.30.1.1"=>"r001i01b","SNMPv2-SMI::enterprises.59.3.800.30.10.1.1"=>"SYSPOWERSTATE","SNMPv2-SMI::enterprises.59.3.800.30.10.1.2"=>"0x0","SNMPv2-SMI::enterprises.59.3.800.30.10.1.4"=>"18","host"=>"192.168.254.61"
         }
     ]
     filtered_records = filter(records)
     assert_equal records[0]['message'], filtered_records[0]['message']
     assert_equal 'HPE:testcolo:UV300-00000550', filtered_records[0]['machineId']
+    assert_equal 'SYSPOWERSTATE', filtered_records[0]['device']
     assert_equal 'Server Power ON', filtered_records[0]['event']
     assert_equal 'on', filtered_records[0]['status']
-    assert_equal 'SYSPOWERSTATE', filtered_records[0]['type']
     assert_equal 'info', filtered_records[0]['severity']
-    assert_equal '0x0', filtered_records[0]['device']
     assert_equal '', filtered_records[0]['error']
   end
 
@@ -60,18 +56,36 @@ class ProcessSnmptrapFilterTest < Test::Unit::TestCase
   def test_poweron_filter
     records = [
         {
-                "SNMPv2-MIB::sysUpTime.0":"43 days, 21:28:56.10","SNMPv2-MIB::snmpTrapOID.0":"SNMPv2-SMI::enterprises.59.3.800.100.20.3","SNMPv2-SMI::enterprises.59.3.800.10.10.1.1":"UV300-00000550","SNMPv2-SMI::enterprises.59.3.800.10.30.1.1":"r001i01b","SNMPv2-SMI::enterprises.59.3.800.30.10.1.1":"SYSPOWERSTATE","SNMPv2-SMI::enterprises.59.3.800.30.10.1.2":"0x0","SNMPv2-SMI::enterprises.59.3.800.30.10.1.4":"19","host":"192.168.254.61"
+              "SNMPv2-MIB::sysUpTime.0"=>"43 days, 21:28:56.10","SNMPv2-MIB::snmpTrapOID.0"=>"SNMPv2-SMI::enterprises.59.3.800.100.20.3","SNMPv2-SMI::enterprises.59.3.800.10.10.1.1"=>"UV300-00000550","SNMPv2-SMI::enterprises.59.3.800.10.30.1.1"=>"r001i01b","SNMPv2-SMI::enterprises.59.3.800.30.10.1.1"=>"SYSPOWERSTATE","SNMPv2-SMI::enterprises.59.3.800.30.10.1.2"=>"0x0","SNMPv2-SMI::enterprises.59.3.800.30.10.1.4"=>"19","host"=>"192.168.254.61"
         }
     ]
+
     filtered_records = filter(records)
     assert_equal records[0]['message'], filtered_records[0]['message']
     assert_equal 'HPE:testcolo:UV300-00000550', filtered_records[0]['machineId']
+    assert_equal 'SYSPOWERSTATE', filtered_records[0]['device']
     assert_equal 'Server Power OFF', filtered_records[0]['event']
-    assert_equal 'on', filtered_records[0]['status']
-    assert_equal 'SYSPOWERSTATE', filtered_records[0]['type']
+    assert_equal 'off', filtered_records[0]['status']
     assert_equal 'info', filtered_records[0]['severity']
-    assert_equal '0x0', filtered_records[0]['device']
     assert_equal '', filtered_records[0]['error']
   end
+
+  def test_temp_filter
+      records = [
+          {
+              "SNMPv2-MIB::sysUpTime.0"=>"177 days, 22:47:08.51","SNMPv2-MIB::snmpTrapOID.0"=>"SNMPv2-SMI::enterprises.59.3.800.100.20.3","SNMPv2-SMI::enterprises.59.3.800.10.10.1.1"=>"UV300-00000547","SNMPv2-SMI::enterprises.59.3.800.10.30.1.1"=>"r001i24b","SNMPv2-SMI::enterprises.59.3.800.30.10.1.1"=>"PSU2_ENV_TEMP2","SNMPv2-SMI::enterprises.59.3.800.30.10.1.2"=>"NA","SNMPv2-SMI::enterprises.59.3.800.30.10.1.4"=>"0","host"=>"172.17.0.2"
+          }
+      ]
+    filtered_records = filter(records)
+    assert_equal records[0]['message'], filtered_records[0]['message']
+    assert_equal 'HPE:testcolo:UV300-00000547', filtered_records[0]['machineId']
+    assert_equal 'PSU2_ENV_TEMP2', filtered_records[0]['device']
+    assert_equal 'Chassis Sensor Event', filtered_records[0]['event']
+    assert_equal 'unavailable', filtered_records[0]['status']
+    assert_equal 'NA', filtered_records[0]['sensorValue']
+    assert_equal 'info', filtered_records[0]['severity']
+    assert_equal '', filtered_records[0]['error']
+  end
+
 end
 


### PR DESCRIPTION
Change variable names to be consistent with the other filters, remove unneeded fields, add trap source IP. Small cleanup and fixing unit tests.