### PR TITLE
Upgrade bundler to version 2.2.10 or later to mitigate vulnerability

### DIFF
--- a/fluent-plugin-process-snmptrap.gemspec
+++ b/fluent-plugin-process-snmptrap.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = test_files
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]


### PR DESCRIPTION
**Change:** Fix https://github.com/advisories/GHSA-fp4w-jxhp-m23p

**Testing:** Deployed built image referencing this brach to an environment with SNMP telemetry; verified presence of end-to-end telemetry and no errors